### PR TITLE
New touch() media query

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,10 @@ Add a media query for screen when the viewport is taller than it is wide or in p
 
 Add media queries for devices with hover over element's ability
 
+#### touch()
+
+Add media queries for devices with touch only ability
+
 #### Mixins Arguments
 
 Almost all mixins receive parameters to make media query more specific.

--- a/README.md
+++ b/README.md
@@ -205,13 +205,21 @@ Media query kicks in above the specified value, index or scale name
 
 Alias to ```above()```
 
+#### from(value)
+
+Alias to ```above()``` using breakpoint-slicer syntax
+
 #### below(value)
 
 Media query kicks in below the specified value, index or scale name
 
-#### to-width(value)
+#### to-width(value) 
 
 Alias to ```below()```
+
+#### to(value) 
+
+Alias to ```below()``` using breakpoint-slicer syntax
 
 #### between(minVal, maxVal)
 

--- a/rupture.scss
+++ b/rupture.scss
@@ -353,3 +353,16 @@ $rupture: map-merge($rupture, ( scale: 0 map-get($rupture, mobile-cutoff) 600px 
     @content;
   }
 }
+
+@mixin rupture-touch($density: null, $orientation: null, $fallback-class: null) {
+  $condition: 'only screen and (hover: none)';
+  @media #{$condition} {
+    @content;
+  }
+}
+
+@mixin touch($args...) {
+  @include rupture-touch($args...) {
+    @content;
+  }
+}

--- a/rupture.scss
+++ b/rupture.scss
@@ -227,6 +227,12 @@ $rupture: map-merge($rupture, ( scale: 0 map-get($rupture, mobile-cutoff) 600px 
   }
 }
 
+@mixin from($args...) {
+  @include from-width($args...) {
+    @content;
+  }
+}
+
 @mixin to-width($scale-point, $anti-overlap: map-get($rupture, anti-overlap), $density: null, $orientation: null, $use-device-width: map-get($rupture, use-device-width), $fallback-class: null) {
   @include between(1, $scale-point, $anti-overlap, $density, $orientation, $use-device-width, $fallback-class) {
     @content;
@@ -234,6 +240,12 @@ $rupture: map-merge($rupture, ( scale: 0 map-get($rupture, mobile-cutoff) 600px 
 }
 
 @mixin below($args...) {
+  @include to-width($args...) {
+    @content;
+  }
+}
+
+@mixin to($args...) {
   @include to-width($args...) {
     @content;
   }


### PR DESCRIPTION
@ CubaSAN Great framework! I've recently switch from breakpoint slicer, using SASS, and I found this way better.

As opposite of `hover()`, the new `touch()` mixin is intended to target screens without a primary pointer, as stated in [this CSS tricks article](https://css-tricks.com/touch-devices-not-judged-size/):

> Primary input mechanism cannot hover at all or cannot conveniently hover (e.g., many mobile devices emulate hovering when the user performs an inconvenient long tap), or there is no primary pointing input mechanism
> `@media (hover: none) { ... }`

Thanks for your work, I hope my contribution is appreciated.