### PR TITLE
🎨 Refactor for upcoming version of Sass

### DIFF
--- a/rupture.scss
+++ b/rupture.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 $base-font-size: 16px !default;
 $rasterise-media-queries: false !default;
 $rupture: ( rasterise-media-queries: $rasterise-media-queries, mobile-cutoff: 400px, desktop-cutoff: 1050px, hd-cutoff: 1800px, enable-em-breakpoints: false, base-font-size: $base-font-size, anti-overlap: false, density-queries: 'dppx' 'webkit' 'moz' 'dpi', retina-density: 1.5, use-device-width: false);
@@ -37,7 +38,7 @@ $rupture: map-merge($rupture, ( scale: 0 map-get($rupture, mobile-cutoff) 600px 
     }
     @else {
       $digits: $digits * 10;
-      $result: $result + map-get($numbers, $character) / $digits;
+      $result: $result + math.div(map-get($numbers, $character), $digits);
     }
   }
   @return if($minus, -$result, $result);
@@ -46,7 +47,7 @@ $rupture: map-merge($rupture, ( scale: 0 map-get($rupture, mobile-cutoff) 600px 
 
 @function _strip-units($number) {
   $number: _number($number);
-  @return $number / ($number * 0 + 1);
+  @return math.div($number, $number * 0 + 1);
 }
 
 @function _is-string($val) {
@@ -71,7 +72,7 @@ $rupture: map-merge($rupture, ( scale: 0 map-get($rupture, mobile-cutoff) 600px 
     @if ($from-unit=='em' or $from-unit=='rem') {
       @return $value;
     }
-    @return "#{_strip-units($value) / _strip-units($context)}#{$to-unit}";
+    @return "#{math.div(_strip-units($value), _strip-units($context))}#{$to-unit}";
   }
   @if ($to-unit=='px') {
     @return "#{_strip-units($value) * _strip-units($context)}px";
@@ -133,7 +134,7 @@ $rupture: map-merge($rupture, ( scale: 0 map-get($rupture, mobile-cutoff) 600px 
       $queries: append($queries, '(min--moz-device-pixel-ratio: #{$density})');
     }
     @else if $query=='o' {
-      $queries: append($queries, '(-o_min-device-pixel-ratio: #{$density}/1)');
+      $queries: append($queries, '(-o-min-device-pixel-ratio: #{$density}/1)');
     }
     @else if $query=='ratio' {
       $queries: append($queries, '(min-device-pixel-ratio: #{$density})');


### PR DESCRIPTION
Hi there,
thanks for the port of Rupture from Stylus to Sass. I really appreciate being able to use that. Recently, I've upgraded a bunch of repos to use the latest version of [Sass](https://www.npmjs.com/package/sass) and Webpack@5 and a deprecation warning started to show up during the compilation. Rather than just opening a new issue, I decided to be more proactive and offer a solution. Please consider my pull request.

Details:
---

* Resolve the deprecation warning displayed during the compilation in
  Webpack:

```
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($number, $number * 0 + 1)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
49 │   @return $number / ($number * 0 + 1);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/rupture-sass/rupture.scss 49:11                                        -strip-units()
    node_modules/rupture-sass/rupture.scss 177:14                                       between()
    node_modules/rupture-sass/rupture.scss 219:3                                        from-width()
    node_modules/rupture-sass/rupture.scss 225:3                                        above()
    node_modules/@npm_leadtech/cvgb-sass-placeholders/placeholders/_headings.scss 75:9  @import
    node_modules/@npm_leadtech/cvgb-sass-placeholders/placeholders.scss 1:9             @import
    src/scss/main.scss 6:9                                                              root stylesheet

```
  > Using / for division is deprecated and will be removed in Dart Sass 2.0.0. More info https://sass-lang.com/documentation/breaking-changes/slash-div

* Fix typo in `-o_min-device-pixel-ratio`