### PR TITLE
feat: update rupture for compatibility with modern scss

### DIFF
--- a/rupture.scss
+++ b/rupture.scss
@@ -1,10 +1,30 @@
-@use "sass:math";
+@use 'sass:math';
+@use 'sass:map';
 $base-font-size: 16px !default;
 $rasterise-media-queries: false !default;
-$rupture: ( rasterise-media-queries: $rasterise-media-queries, mobile-cutoff: 400px, desktop-cutoff: 1050px, hd-cutoff: 1800px, enable-em-breakpoints: false, base-font-size: $base-font-size, anti-overlap: false, density-queries: 'dppx' 'webkit' 'moz' 'dpi', retina-density: 1.5, use-device-width: false);
-$rupture: map-merge($rupture, ( scale: 0 map-get($rupture, mobile-cutoff) 600px 800px map-get($rupture, desktop-cutoff) map-get($rupture, hd-cutoff), scale-names: 'xs' 's' 'm' 'l' 'xl' 'hd'));
+$rupture: (
+  rasterise-media-queries: $rasterise-media-queries,
+  mobile-cutoff: 400px,
+  desktop-cutoff: 1050px,
+  hd-cutoff: 1800px,
+  enable-em-breakpoints: false,
+  base-font-size: $base-font-size,
+  anti-overlap: false,
+  density-queries: 'dppx' 'webkit' 'moz' 'dpi',
+  retina-density: 1.5,
+  use-device-width: false,
+);
+$rupture: map.merge(
+  $rupture,
+  (
+    scale: 0 map.get($rupture, mobile-cutoff) 600px 800px
+      map.get($rupture, desktop-cutoff) map.get($rupture, hd-cutoff),
+    scale-names: 'xs' 's' 'm' 'l' 'xl' 'hd',
+  )
+);
 @function _to-length($number, $unit) {
-  $strings: 'px' 'cm' 'mm' '%' 'ch' 'pica' 'in' 'em' 'rem' 'pt' 'pc' 'ex' 'vw' 'vh' 'vmin' 'vmax';
+  $strings: 'px' 'cm' 'mm' '%' 'ch' 'pica' 'in' 'em' 'rem' 'pt' 'pc' 'ex' 'vw'
+    'vh' 'vmin' 'vmax';
   $units: 1px 1cm 1mm 1% 1ch 1pica 1in 1em 1rem 1pt 1pc 1ex 1vw 1vh 1vmin 1vmax;
   $index: index($strings, $unit);
   @if not $index {
@@ -15,34 +35,41 @@ $rupture: map-merge($rupture, ( scale: 0 map-get($rupture, mobile-cutoff) 600px 
 }
 
 @function _number($value) {
-  @if type-of($value)=='number' {
+  @if type-of($value) == 'number' {
     @return $value;
-  }
-  @else if type-of($value) !='string' {
+  } @else if type-of($value) != 'string' {
     $_: log('Value for `to-number` should be a number or a string.');
   }
   $result: 0;
   $digits: 0;
-  $minus: str-slice($value, 1, 1)=='-';
-  $numbers: ('0': 0, '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8, '9': 9);
+  $minus: str-slice($value, 1, 1) == '-';
+  $numbers: (
+    '0': 0,
+    '1': 1,
+    '2': 2,
+    '3': 3,
+    '4': 4,
+    '5': 5,
+    '6': 6,
+    '7': 7,
+    '8': 8,
+    '9': 9,
+  );
   @for $i from if($minus, 2, 1) through str-length($value) {
     $character: str-slice($value, $i, $i);
-    @if not (index(map-keys($numbers), $character) or $character=='.') {
-      @return _to-length(if($minus, -$result, $result), str-slice($value, $i))
+    @if not(index(map.keys($numbers), $character) or $character== '.') {
+      @return _to-length(if($minus, -$result, $result), str-slice($value, $i));
     }
-    @if $character=='.' {
+    @if $character== '.' {
       $digits: 1;
-    }
-    @else if $digits==0 {
-      $result: $result * 10 + map-get($numbers, $character);
-    }
-    @else {
+    } @else if $digits==0 {
+      $result: $result * 10 + map.get($numbers, $character);
+    } @else {
       $digits: $digits * 10;
-      $result: $result + math.div(map-get($numbers, $character), $digits);
+      $result: $result + math.div(map.get($numbers, $character), $digits);
     }
   }
   @return if($minus, -$result, $result);
-  ;
 }
 
 @function _strip-units($number) {
@@ -51,40 +78,44 @@ $rupture: map-merge($rupture, ( scale: 0 map-get($rupture, mobile-cutoff) 600px 
 }
 
 @function _is-string($val) {
-  @return type-of($val)=='string';
+  @return type-of($val) == 'string';
 }
 
 @function _get-scale-number($scale-name) {
-  @each $list-item in map-get($rupture, scale-names) {
+  @each $list-item in map.get($rupture, scale-names) {
     @if ($list-item==$scale-name) {
-      @return index(map-get($rupture, scale-names), $list-item);
+      @return index(map.get($rupture, scale-names), $list-item);
     }
   }
   @return false;
 }
 
-@function _convert-to($to-unit, $value, $context: map-get($rupture, base-font-size)) {
+@function _convert-to(
+  $to-unit,
+  $value,
+  $context: map.get($rupture, base-font-size)
+) {
   $from-unit: unit(_number($value));
   @if ($to-unit==$from-unit) {
     @return $value;
   }
-  @if ($to-unit=='em' or $to-unit=='rem') {
-    @if ($from-unit=='em' or $from-unit=='rem') {
+  @if ($to-unit== 'em' or $to-unit== 'rem') {
+    @if ($from-unit== 'em' or $from-unit== 'rem') {
       @return $value;
     }
-    @return "#{math.div(_strip-units($value), _strip-units($context))}#{$to-unit}";
+    @return '#{math.div(_strip-units($value), _strip-units($context))}#{$to-unit}';
   }
-  @if ($to-unit=='px') {
-    @return "#{_strip-units($value) * _strip-units($context)}px";
+  @if ($to-unit== 'px') {
+    @return '#{_strip-units($value) * _strip-units($context)}px';
   }
 }
 
 @function _on-scale($n) {
-  @return unit(_number($n))=='';
+  @return unit(_number($n)) == '';
 }
 
 @function _larger-than-scale($n) {
-  @return ($n >=(length(map-get($rupture, scale)))) and _on-scale($n);
+  @return ($n >=(length(map.get($rupture, scale)))) and _on-scale($n);
 }
 
 @function _is-zero($n) {
@@ -99,50 +130,53 @@ $rupture: map-merge($rupture, ( scale: 0 map-get($rupture, mobile-cutoff) 600px 
   @if ($anti-overlap==true) {
     $anti-overlap: 1px;
   }
-  @if (length($anti-overlap)==1) {
+  @if (length($anti-overlap) ==1) {
     @return _convert-to($shift-unit, $anti-overlap);
   }
   @each $val in $anti-overlap {
-    @if (unit(_number($val))==$shift-unit) {
+    @if (unit(_number($val)) ==$shift-unit) {
       @return $val;
     }
   }
 }
 
 @function _add($var1, $var2) {
-  @return _number($var1)+_number($var2);
+  @return _number($var1) + _number($var2);
 }
 
 @function _adjust-overlap($anti-overlap, $n, $side: 'min') {
   $_shift: _overlap-shift($anti-overlap, $n);
-  @if ($side=='min' and _strip-units($_shift) > 0) or ($side=='max' and _strip-units($_shift) < 0) {
+  @if ($side== 'min' and _strip-units($_shift) > 0) or
+    ($side== 'max' and _strip-units($_shift) < 0)
+  {
     $n: _add($n, $_shift);
   }
   @return $n;
 }
 
 @function _density-queries($density) {
-  @if ($density=='retina') {
-    $density: map-get($rupture, retina-density);
+  @if ($density== 'retina') {
+    $density: map.get($rupture, retina-density);
   }
   $queries: ();
-  @each $query in map-get($rupture, density-queries) {
-    @if $query=='webkit' {
-      $queries: append($queries, '(-webkit_min-device-pixel-ratio: #{$density})');
-    }
-    @else if $query=='moz' {
+  @each $query in map.get($rupture, density-queries) {
+    @if $query== 'webkit' {
+      $queries: append(
+        $queries,
+        '(-webkit_min-device-pixel-ratio: #{$density})'
+      );
+    } @else if $query== 'moz' {
       $queries: append($queries, '(min--moz-device-pixel-ratio: #{$density})');
-    }
-    @else if $query=='o' {
+    } @else if $query== 'o' {
       $queries: append($queries, '(-o-min-device-pixel-ratio: #{$density}/1)');
-    }
-    @else if $query=='ratio' {
+    } @else if $query== 'ratio' {
       $queries: append($queries, '(min-device-pixel-ratio: #{$density})');
-    }
-    @else if $query=='dpi' {
-      $queries: append($queries, '(min-resolution: #{round($density * 96)}dpi)');
-    }
-    @else if $query=='dppx' {
+    } @else if $query== 'dpi' {
+      $queries: append(
+        $queries,
+        '(min-resolution: #{round($density * 96)}dpi)'
+      );
+    } @else if $query== 'dppx' {
       $queries: append($queries, '(min-resolution: #{$density}dppx)');
     }
   }
@@ -155,7 +189,15 @@ $rupture: map-merge($rupture, ( scale: 0 map-get($rupture, mobile-cutoff) 600px 
   }
 }
 
-@mixin between($min, $max, $anti-overlap: map-get($rupture, anti-overlap), $density: null, $orientation: null, $use-device-width: map-get($rupture, use-device-width), $fallback-class: null) {
+@mixin between(
+  $min,
+  $max,
+  $anti-overlap: map.get($rupture, anti-overlap),
+  $density: null,
+  $orientation: null,
+  $use-device-width: map.get($rupture, use-device-width),
+  $fallback-class: null
+) {
   $selected: &;
   $initial_min: $min;
   $initial_max: $max;
@@ -165,32 +207,45 @@ $rupture: map-merge($rupture, ( scale: 0 map-get($rupture, mobile-cutoff) 600px 
   @if _is-string($max) {
     $max: _get-scale-number($max);
   }
-  $_min: if(_is-zero($min) or (not _on-scale($min)), $min, nth(map-get($rupture, scale), $min));
-  $_max: if(_is-string($initial_max) and _on-scale($max), nth(map-get($rupture, scale), $max + 1), $max);
-  @if (map-get($rupture, rasterise-media-queries)) {
-    @if not ($density or $_max or $orientation) {
+  $_min: if(
+    _is-zero($min) or (not _on-scale($min)),
+    $min,
+    nth(map.get($rupture, scale), $min)
+  );
+  $_max: if(
+    _is-string($initial_max) and _on-scale($max),
+    nth(map.get($rupture, scale), $max + 1),
+    $max
+  );
+  @if (map.get($rupture, rasterise-media-queries)) {
+    @if not($density or $_max or $orientation) {
       @content;
     }
-  }
-  @else {
+  } @else {
     $condition: 'only screen';
     $use-device-width: if($use-device-width, 'device-', '');
-    @if not (_strip-units($_min)==0) {
-      @if (map-get($rupture, enable-em-breakpoints)) {
+    @if not(_strip-units($_min) ==0) {
+      @if (map.get($rupture, enable-em-breakpoints)) {
         $_min: _convert-to('em', $_min);
       }
       $_min: _adjust-overlap($anti-overlap, $_min, $side: 'min');
-      $condition: $condition+' and (min-'+$use-device-width+'width: #{$_min})';
+      $condition: $condition +
+        ' and (min-' +
+        $use-device-width +
+        'width: #{$_min})';
     }
-    @if not (_larger-than-scale($max)) {
-      @if (map-get($rupture, enable-em-breakpoints)) {
+    @if not(_larger-than-scale($max)) {
+      @if (map.get($rupture, enable-em-breakpoints)) {
         $_max: _convert-to('em', $_max);
       }
       $_max: _adjust-overlap($anti-overlap, $_max, $side: 'max');
-      $condition: $condition+' and (max-'+$use-device-width+'width: #{$_max})';
+      $condition: $condition +
+        ' and (max-' +
+        $use-device-width +
+        'width: #{$_max})';
     }
     @if $orientation {
-      $condition: $condition+' and (orientation: #{$orientation})';
+      $condition: $condition + ' and (orientation: #{$orientation})';
     }
     @if $density {
       $conditions: ();
@@ -210,14 +265,44 @@ $rupture: map-merge($rupture, ( scale: 0 map-get($rupture, mobile-cutoff) 600px 
   }
 }
 
-@mixin at($scale-point, $anti-overlap: map-get($rupture, anti-overlap), $density: null, $orientation: null, $use-device-width: map-get($rupture, use-device-width), $fallback-class: null) {
-  @include between($scale-point, $scale-point, $anti-overlap, $density, $orientation, $use-device-width, $fallback-class) {
+@mixin at(
+  $scale-point,
+  $anti-overlap: map.get($rupture, anti-overlap),
+  $density: null,
+  $orientation: null,
+  $use-device-width: map.get($rupture, use-device-width),
+  $fallback-class: null
+) {
+  @include between(
+    $scale-point,
+    $scale-point,
+    $anti-overlap,
+    $density,
+    $orientation,
+    $use-device-width,
+    $fallback-class
+  ) {
     @content;
   }
 }
 
-@mixin from-width($scale-point, $anti-overlap: map-get($rupture, anti-overlap), $density: null, $orientation: null, $use-device-width: map-get($rupture, use-device-width), $fallback-class: null) {
-  @include between($scale-point, length(map-get($rupture, scale)), $anti-overlap, $density, $orientation, $use-device-width, $fallback-class) {
+@mixin from-width(
+  $scale-point,
+  $anti-overlap: map.get($rupture, anti-overlap),
+  $density: null,
+  $orientation: null,
+  $use-device-width: map.get($rupture, use-device-width),
+  $fallback-class: null
+) {
+  @include between(
+    $scale-point,
+    length(map.get($rupture, scale)),
+    $anti-overlap,
+    $density,
+    $orientation,
+    $use-device-width,
+    $fallback-class
+  ) {
     @content;
   }
 }
@@ -234,8 +319,23 @@ $rupture: map-merge($rupture, ( scale: 0 map-get($rupture, mobile-cutoff) 600px 
   }
 }
 
-@mixin to-width($scale-point, $anti-overlap: map-get($rupture, anti-overlap), $density: null, $orientation: null, $use-device-width: map-get($rupture, use-device-width), $fallback-class: null) {
-  @include between(1, $scale-point, $anti-overlap, $density, $orientation, $use-device-width, $fallback-class) {
+@mixin to-width(
+  $scale-point,
+  $anti-overlap: map.get($rupture, anti-overlap),
+  $density: null,
+  $orientation: null,
+  $use-device-width: map.get($rupture, use-device-width),
+  $fallback-class: null
+) {
+  @include between(
+    1,
+    $scale-point,
+    $anti-overlap,
+    $density,
+    $orientation,
+    $use-device-width,
+    $fallback-class
+  ) {
     @content;
   }
 }
@@ -252,38 +352,91 @@ $rupture: map-merge($rupture, ( scale: 0 map-get($rupture, mobile-cutoff) 600px 
   }
 }
 
-@mixin mobile($anti-overlap: map-get($rupture, anti-overlap), $density: null, $orientation: null, $use-device-width: map-get($rupture, use-device-width), $fallback-class: null) {
-  @include below(map-get($rupture, mobile-cutoff), $anti-overlap, $density, $orientation, $use-device-width, $fallback-class) {
+@mixin mobile(
+  $anti-overlap: map.get($rupture, anti-overlap),
+  $density: null,
+  $orientation: null,
+  $use-device-width: map.get($rupture, use-device-width),
+  $fallback-class: null
+) {
+  @include below(
+    map.get($rupture, mobile-cutoff),
+    $anti-overlap,
+    $density,
+    $orientation,
+    $use-device-width,
+    $fallback-class
+  ) {
     @content;
   }
 }
 
-@mixin tablet($anti-overlap: map-get($rupture, anti-overlap), $density: null, $orientation: null, $use-device-width: map-get($rupture, use-device-width), $fallback-class: null) {
-  @include between(map-get($rupture, mobile-cutoff), map-get($rupture, desktop-cutoff), $anti-overlap, $density, $orientation, $use-device-width, $fallback-class) {
+@mixin tablet(
+  $anti-overlap: map.get($rupture, anti-overlap),
+  $density: null,
+  $orientation: null,
+  $use-device-width: map.get($rupture, use-device-width),
+  $fallback-class: null
+) {
+  @include between(
+    map.get($rupture, mobile-cutoff),
+    map.get($rupture, desktop-cutoff),
+    $anti-overlap,
+    $density,
+    $orientation,
+    $use-device-width,
+    $fallback-class
+  ) {
     @content;
   }
 }
 
-@mixin desktop($anti-overlap: map-get($rupture, anti-overlap), $density: null, $orientation: null, $use-device-width: map-get($rupture, use-device-width), $fallback-class: null) {
-  @include above(map-get($rupture, desktop-cutoff), $anti-overlap, $density, $orientation, $use-device-width, $fallback-class) {
+@mixin desktop(
+  $anti-overlap: map.get($rupture, anti-overlap),
+  $density: null,
+  $orientation: null,
+  $use-device-width: map.get($rupture, use-device-width),
+  $fallback-class: null
+) {
+  @include above(
+    map.get($rupture, desktop-cutoff),
+    $anti-overlap,
+    $density,
+    $orientation,
+    $use-device-width,
+    $fallback-class
+  ) {
     @content;
   }
 }
 
-@mixin hd($anti-overlap: map-get($rupture, anti-overlap), $density: null, $orientation: null, $use-device-width: map-get($rupture, use-device-width), $fallback-class: null) {
-  @include above(map-get($rupture, hd-cutoff), $anti-overlap, $density, $orientation, $use-device-width, $fallback-class) {
+@mixin hd(
+  $anti-overlap: map.get($rupture, anti-overlap),
+  $density: null,
+  $orientation: null,
+  $use-device-width: map.get($rupture, use-device-width),
+  $fallback-class: null
+) {
+  @include above(
+    map.get($rupture, hd-cutoff),
+    $anti-overlap,
+    $density,
+    $orientation,
+    $use-device-width,
+    $fallback-class
+  ) {
     @content;
   }
 }
 
 @mixin density($density, $fallback-class: null, $orientation: null) {
   $selected: &;
-  @if not map-get($rupture, rasterise-media-queries) {
+  @if not map.get($rupture, rasterise-media-queries) {
     $conditions: ();
     @each $query in _density-queries($density) {
       $condition: 'only screen and #{$query}';
       @if $orientation {
-        $condition: $condition+' and (orientation: #{$orientation})';
+        $condition: $condition + ' and (orientation: #{$orientation})';
       }
       $conditions: append($conditions, $condition, comma);
     }
@@ -309,18 +462,16 @@ $rupture: map-merge($rupture, ( scale: 0 map-get($rupture, mobile-cutoff) 600px 
   @include density('retina', $fallback-class, $orientation) {
     @content;
   }
-  ;
 }
 
 @mixin landscape($density: null, $fallback-class: null) {
   $selected: &;
-  @if not map-get($rupture, rasterise-media-queries) {
+  @if not map.get($rupture, rasterise-media-queries) {
     @if $density {
       @include pixel-ratio($density, $fallback-class, $orientation: landscape) {
         @content;
       }
-    }
-    @else {
+    } @else {
       @media only screen and (orientation: landscape) {
         @content;
       }
@@ -335,13 +486,12 @@ $rupture: map-merge($rupture, ( scale: 0 map-get($rupture, mobile-cutoff) 600px 
 
 @mixin portrait($density: null, $fallback-class: null) {
   $selected: &;
-  @if not map-get($rupture, rasterise-media-queries) {
+  @if not map.get($rupture, rasterise-media-queries) {
     @if $density {
       @include pixel-ratio($density, $fallback-class, $orientation: portrait) {
         @content;
       }
-    }
-    @else {
+    } @else {
       @media only screen and (orientation: portrait) {
         @content;
       }
@@ -354,7 +504,11 @@ $rupture: map-merge($rupture, ( scale: 0 map-get($rupture, mobile-cutoff) 600px 
   }
 }
 
-@mixin rupture-hover($density: null, $orientation: null, $fallback-class: null) {
+@mixin rupture-hover(
+  $density: null,
+  $orientation: null,
+  $fallback-class: null
+) {
   $condition: 'only screen and (hover: hover)';
   @media #{$condition} {
     @content;
@@ -367,7 +521,11 @@ $rupture: map-merge($rupture, ( scale: 0 map-get($rupture, mobile-cutoff) 600px 
   }
 }
 
-@mixin rupture-touch($density: null, $orientation: null, $fallback-class: null) {
+@mixin rupture-touch(
+  $density: null,
+  $orientation: null,
+  $fallback-class: null
+) {
   $condition: 'only screen and (hover: none)';
   @media #{$condition} {
     @content;

--- a/rupture.scss
+++ b/rupture.scss
@@ -1,5 +1,7 @@
 @use 'sass:math';
 @use 'sass:map';
+@use 'sass:list';
+@use 'sass:meta';
 $base-font-size: 16px !default;
 $rasterise-media-queries: false !default;
 $rupture: (
@@ -26,18 +28,18 @@ $rupture: map.merge(
   $strings: 'px' 'cm' 'mm' '%' 'ch' 'pica' 'in' 'em' 'rem' 'pt' 'pc' 'ex' 'vw'
     'vh' 'vmin' 'vmax';
   $units: 1px 1cm 1mm 1% 1ch 1pica 1in 1em 1rem 1pt 1pc 1ex 1vw 1vh 1vmin 1vmax;
-  $index: index($strings, $unit);
+  $index: list.index($strings, $unit);
   @if not $index {
     @warn "Unknown unit `#{$unit}`.";
     @return false;
   }
-  @return $number * nth($units, $index);
+  @return $number * list.nth($units, $index);
 }
 
 @function _number($value) {
-  @if type-of($value) == 'number' {
+  @if meta.type-of($value) == 'number' {
     @return $value;
-  } @else if type-of($value) != 'string' {
+  } @else if meta.type-of($value) != 'string' {
     $_: log('Value for `to-number` should be a number or a string.');
   }
   $result: 0;
@@ -57,7 +59,7 @@ $rupture: map.merge(
   );
   @for $i from if($minus, 2, 1) through str-length($value) {
     $character: str-slice($value, $i, $i);
-    @if not(index(map.keys($numbers), $character) or $character== '.') {
+    @if not(list.index(map.keys($numbers), $character) or $character== '.') {
       @return _to-length(if($minus, -$result, $result), str-slice($value, $i));
     }
     @if $character== '.' {
@@ -78,13 +80,13 @@ $rupture: map.merge(
 }
 
 @function _is-string($val) {
-  @return type-of($val) == 'string';
+  @return meta.type-of($val) == 'string';
 }
 
 @function _get-scale-number($scale-name) {
   @each $list-item in map.get($rupture, scale-names) {
     @if ($list-item==$scale-name) {
-      @return index(map.get($rupture, scale-names), $list-item);
+      @return list.index(map.get($rupture, scale-names), $list-item);
     }
   }
   @return false;
@@ -95,7 +97,7 @@ $rupture: map.merge(
   $value,
   $context: map.get($rupture, base-font-size)
 ) {
-  $from-unit: unit(_number($value));
+  $from-unit: math.unit(_number($value));
   @if ($to-unit==$from-unit) {
     @return $value;
   }
@@ -111,11 +113,11 @@ $rupture: map.merge(
 }
 
 @function _on-scale($n) {
-  @return unit(_number($n)) == '';
+  @return math.unit(_number($n)) == '';
 }
 
 @function _larger-than-scale($n) {
-  @return ($n >=(length(map.get($rupture, scale)))) and _on-scale($n);
+  @return ($n >=(list.length(map.get($rupture, scale)))) and _on-scale($n);
 }
 
 @function _is-zero($n) {
@@ -123,18 +125,18 @@ $rupture: map.merge(
 }
 
 @function _overlap-shift($anti-overlap, $n) {
-  $shift-unit: unit(_number($n));
+  $shift-unit: math.unit(_number($n));
   @if not $anti-overlap {
     $anti-overlap: 0px;
   }
   @if ($anti-overlap==true) {
     $anti-overlap: 1px;
   }
-  @if (length($anti-overlap) ==1) {
+  @if (list.length($anti-overlap) ==1) {
     @return _convert-to($shift-unit, $anti-overlap);
   }
   @each $val in $anti-overlap {
-    @if (unit(_number($val)) ==$shift-unit) {
+    @if (math.unit(_number($val)) ==$shift-unit) {
       @return $val;
     }
   }
@@ -210,11 +212,11 @@ $rupture: map.merge(
   $_min: if(
     _is-zero($min) or (not _on-scale($min)),
     $min,
-    nth(map.get($rupture, scale), $min)
+    list.nth(map.get($rupture, scale), $min)
   );
   $_max: if(
     _is-string($initial_max) and _on-scale($max),
-    nth(map.get($rupture, scale), $max + 1),
+    list.nth(map.get($rupture, scale), $max + 1),
     $max
   );
   @if (map.get($rupture, rasterise-media-queries)) {
@@ -296,7 +298,7 @@ $rupture: map.merge(
 ) {
   @include between(
     $scale-point,
-    length(map.get($rupture, scale)),
+    list.length(map.get($rupture, scale)),
     $anti-overlap,
     $density,
     $orientation,

--- a/rupture.scss
+++ b/rupture.scss
@@ -1,9 +1,13 @@
+@use 'sass:string';
 @use 'sass:math';
 @use 'sass:map';
 @use 'sass:list';
 @use 'sass:meta';
+
 $base-font-size: 16px !default;
 $rasterise-media-queries: false !default;
+
+// Make $rupture configurable with !default flag
 $rupture: (
   rasterise-media-queries: $rasterise-media-queries,
   mobile-cutoff: 400px,
@@ -15,7 +19,8 @@ $rupture: (
   density-queries: 'dppx' 'webkit' 'moz' 'dpi',
   retina-density: 1.5,
   use-device-width: false,
-);
+) !default;
+
 $rupture: map.merge(
   $rupture,
   (
@@ -24,6 +29,7 @@ $rupture: map.merge(
     scale-names: 'xs' 's' 'm' 'l' 'xl' 'hd',
   )
 );
+
 @function _to-length($number, $unit) {
   $strings: 'px' 'cm' 'mm' '%' 'ch' 'pica' 'in' 'em' 'rem' 'pt' 'pc' 'ex' 'vw'
     'vh' 'vmin' 'vmax';
@@ -40,11 +46,12 @@ $rupture: map.merge(
   @if meta.type-of($value) == 'number' {
     @return $value;
   } @else if meta.type-of($value) != 'string' {
-    $_: log('Value for `to-number` should be a number or a string.');
+    @error 'Value for `to-number` should be a number or a string.';
+    @return 0;
   }
   $result: 0;
   $digits: 0;
-  $minus: str-slice($value, 1, 1) == '-';
+  $minus: string.slice($value, 1, 1) == '-';
   $numbers: (
     '0': 0,
     '1': 1,
@@ -57,10 +64,13 @@ $rupture: map.merge(
     '8': 8,
     '9': 9,
   );
-  @for $i from if($minus, 2, 1) through str-length($value) {
-    $character: str-slice($value, $i, $i);
+  @for $i from if($minus, 2, 1) through string.length($value) {
+    $character: string.slice($value, $i, $i);
     @if not(list.index(map.keys($numbers), $character) or $character== '.') {
-      @return _to-length(if($minus, -$result, $result), str-slice($value, $i));
+      @return _to-length(
+        if($minus, -$result, $result),
+        string.slice($value, $i)
+      );
     }
     @if $character== '.' {
       $digits: 1;
@@ -113,33 +123,70 @@ $rupture: map.merge(
 }
 
 @function _on-scale($n) {
-  @return math.unit(_number($n)) == '';
+  @if meta.type-of($n) == 'number' {
+    @return math.unit($n) == '';
+  } @else if meta.type-of($n) == 'string' {
+    @return math.unit(_number($n)) == '';
+  } @else {
+    @return false;
+  }
 }
 
 @function _larger-than-scale($n) {
-  @return ($n >=(list.length(map.get($rupture, scale)))) and _on-scale($n);
+  // First check if $n is a valid number before attempting comparison
+  @if not _on-scale($n) or meta.type-of($n) != 'number' {
+    @return false;
+  }
+  @return $n >= list.length(map.get($rupture, scale));
 }
 
 @function _is-zero($n) {
-  @return n==0;
+  @return $n == 0;
 }
 
 @function _overlap-shift($anti-overlap, $n) {
-  $shift-unit: math.unit(_number($n));
+  // Ensure $n is valid before processing
+  @if meta.type-of($n) != 'number' and meta.type-of($n) != 'string' {
+    @return 0px; // Return a default value if $n is not valid
+  }
+
+  $shift-unit: '';
+  @if meta.type-of($n) == 'number' and math.unit($n) != '' {
+    $shift-unit: math.unit($n);
+  } @else if meta.type-of($n) == 'string' {
+    // Try to extract unit from string
+    @if str-index($n, 'px') != null {
+      $shift-unit: 'px';
+    } @else if str-index($n, 'em') != null {
+      $shift-unit: 'em';
+    } @else if str-index($n, 'rem') != null {
+      $shift-unit: 'rem';
+    } @else if str-index($n, '%') != null {
+      $shift-unit: '%';
+    } @else {
+      $shift-unit: 'px'; // Default to px if unable to determine
+    }
+  } @else {
+    $shift-unit: 'px'; // Default to px for unitless numbers or other cases
+  }
+
   @if not $anti-overlap {
     $anti-overlap: 0px;
   }
-  @if ($anti-overlap==true) {
+  @if ($anti-overlap == true) {
     $anti-overlap: 1px;
   }
-  @if (list.length($anti-overlap) ==1) {
+  @if (list.length($anti-overlap) == 1) {
     @return _convert-to($shift-unit, $anti-overlap);
   }
   @each $val in $anti-overlap {
-    @if (math.unit(_number($val)) ==$shift-unit) {
+    @if meta.type-of($val) == 'number' and math.unit($val) == $shift-unit {
       @return $val;
     }
   }
+
+  // Default return if nothing matches
+  @return 0px;
 }
 
 @function _add($var1, $var2) {
@@ -147,9 +194,14 @@ $rupture: map.merge(
 }
 
 @function _adjust-overlap($anti-overlap, $n, $side: 'min') {
+  // Ensure $n is valid before processing
+  @if meta.type-of($n) != 'number' and meta.type-of($n) != 'string' {
+    @return $n; // Just return the input if it's not valid
+  }
+
   $_shift: _overlap-shift($anti-overlap, $n);
-  @if ($side== 'min' and _strip-units($_shift) > 0) or
-    ($side== 'max' and _strip-units($_shift) < 0)
+  @if ($side == 'min' and _strip-units($_shift) > 0) or
+    ($side == 'max' and _strip-units($_shift) < 0)
   {
     $n: _add($n, $_shift);
   }
@@ -163,23 +215,29 @@ $rupture: map.merge(
   $queries: ();
   @each $query in map.get($rupture, density-queries) {
     @if $query== 'webkit' {
-      $queries: append(
+      $queries: list.append(
         $queries,
         '(-webkit_min-device-pixel-ratio: #{$density})'
       );
     } @else if $query== 'moz' {
-      $queries: append($queries, '(min--moz-device-pixel-ratio: #{$density})');
-    } @else if $query== 'o' {
-      $queries: append($queries, '(-o-min-device-pixel-ratio: #{$density}/1)');
-    } @else if $query== 'ratio' {
-      $queries: append($queries, '(min-device-pixel-ratio: #{$density})');
-    } @else if $query== 'dpi' {
-      $queries: append(
+      $queries: list.append(
         $queries,
-        '(min-resolution: #{round($density * 96)}dpi)'
+        '(min--moz-device-pixel-ratio: #{$density})'
+      );
+    } @else if $query== 'o' {
+      $queries: list.append(
+        $queries,
+        '(-o-min-device-pixel-ratio: #{$density}/1)'
+      );
+    } @else if $query== 'ratio' {
+      $queries: list.append($queries, '(min-device-pixel-ratio: #{$density})');
+    } @else if $query== 'dpi' {
+      $queries: list.append(
+        $queries,
+        '(min-resolution: #{math.round($density * 96)}dpi)'
       );
     } @else if $query== 'dppx' {
-      $queries: append($queries, '(min-resolution: #{$density}dppx)');
+      $queries: list.append($queries, '(min-resolution: #{$density}dppx)');
     }
   }
   @return $queries;
@@ -252,7 +310,11 @@ $rupture: map.merge(
     @if $density {
       $conditions: ();
       @each $query in _density-queries($density) {
-        $conditions: append($conditions, $condition + ' and #{$query}', comma);
+        $conditions: list.append(
+          $conditions,
+          $condition + ' and #{$query}',
+          comma
+        );
       }
       $condition: $conditions;
     }
@@ -440,7 +502,7 @@ $rupture: map.merge(
       @if $orientation {
         $condition: $condition + ' and (orientation: #{$orientation})';
       }
-      $conditions: append($conditions, $condition, comma);
+      $conditions: list.append($conditions, $condition, comma);
     }
     $condition: $conditions;
     @media #{$conditions} {

--- a/rupture.scss
+++ b/rupture.scss
@@ -85,8 +85,27 @@ $rupture: map.merge(
 }
 
 @function _strip-units($number) {
-  $number: _number($number);
-  @return math.div($number, $number * 0 + 1);
+  // First validate that the input is valid before processing
+  @if $number == null {
+    @return 0;
+  }
+  @if meta.type-of($number) != 'number' and meta.type-of($number) != 'string' {
+    @return 0; // Return a safe default
+  }
+
+  // Only apply operations if the value is valid
+  @if meta.type-of($number) == 'number' {
+    // If already a number, strip its units safely
+    @if math.is-unitless($number) {
+      @return $number;
+    } @else {
+      @return math.div($number, $number * 0 + 1);
+    }
+  } @else {
+    // If it's a string, try to convert it first
+    $converted: _number($number);
+    @return math.div($converted, $converted * 0 + 1);
+  }
 }
 
 @function _is-string($val) {
@@ -107,19 +126,49 @@ $rupture: map.merge(
   $value,
   $context: map.get($rupture, base-font-size)
 ) {
-  $from-unit: math.unit(_number($value));
-  @if ($to-unit==$from-unit) {
+  // First validate that $value is a valid input type
+  @if meta.type-of($value) != 'number' and meta.type-of($value) != 'string' {
+    @return 0px; // Return a default value if $value is of invalid type
+  }
+
+  // Only apply unit operations if the value is valid
+  @if meta.type-of($value) == 'number' {
+    $from-unit: if(math.is-unitless($value), '', math.unit($value));
+  } @else {
+    // Try to extract information from string
+    $from-unit: '';
+    // Check for common units in the string without using @break
+    @if string.index($value, 'px') != null {
+      $from-unit: 'px';
+    } @else if string.index($value, 'em') != null {
+      $from-unit: 'em';
+    } @else if string.index($value, 'rem') != null {
+      $from-unit: 'rem';
+    } @else if string.index($value, '%') != null {
+      $from-unit: '%';
+    } @else if string.index($value, 'vh') != null {
+      $from-unit: 'vh';
+    } @else if string.index($value, 'vw') != null {
+      $from-unit: 'vw';
+    }
+  }
+
+  @if $from-unit == $to-unit or $from-unit == '' {
     @return $value;
   }
-  @if ($to-unit== 'em' or $to-unit== 'rem') {
-    @if ($from-unit== 'em' or $from-unit== 'rem') {
+
+  @if ($to-unit == 'em' or $to-unit == 'rem') {
+    @if ($from-unit == 'em' or $from-unit == 'rem') {
       @return $value;
     }
     @return '#{math.div(_strip-units($value), _strip-units($context))}#{$to-unit}';
   }
-  @if ($to-unit== 'px') {
+  @if ($to-unit == 'px') {
     @return '#{_strip-units($value) * _strip-units($context)}px';
   }
+
+  // Default return
+  @return $value;
 }
 
 @function _on-scale($n) {
@@ -154,14 +203,14 @@ $rupture: map.merge(
   @if meta.type-of($n) == 'number' and math.unit($n) != '' {
     $shift-unit: math.unit($n);
   } @else if meta.type-of($n) == 'string' {
-    // Try to extract unit from string
-    @if str-index($n, 'px') != null {
+    // Try to extract unit from string without using @break
+    @if string.index($n, 'px') != null {
       $shift-unit: 'px';
-    } @else if str-index($n, 'em') != null {
+    } @else if string.index($n, 'em') != null {
       $shift-unit: 'em';
-    } @else if str-index($n, 'rem') != null {
+    } @else if string.index($n, 'rem') != null {
       $shift-unit: 'rem';
-    } @else if str-index($n, '%') != null {
+    } @else if string.index($n, '%') != null {
       $shift-unit: '%';
     } @else {
       $shift-unit: 'px'; // Default to px if unable to determine


### PR DESCRIPTION
This pull request includes changes to the `rupture.scss` file to improve code readability and consistency by reformatting the code and using the `map.get` and `map.merge` functions from the `sass:map` module. The most important changes include reformatting the `$rupture` map, updating various functions and mixins to use `map.get`, and improving the readability of string concatenations.

Code readability and consistency improvements:

* Reformatted the `$rupture` map declaration and used the `map.merge` function to merge additional properties.
* Updated all instances of `map-get` to `map.get` for accessing map values. [[1]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L20-L45) [[2]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L58-R97) [[3]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L87-R118) [[4]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L118-R179) [[5]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L158-R200) [[6]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L168-R245) [[7]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L213-R305) [[8]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L237-R338) [[9]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L255-R434) [[10]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L312-R474) [[11]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L338-R494) [[12]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L357-R511)
* Improved readability of string concatenations by using single quotes and consistent spacing. [[1]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L75-R109) [[2]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L118-R179) [[3]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L158-R200)
* Reformatted function and mixin definitions to improve readability by breaking long lines into multiple lines. [[1]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L75-R109) [[2]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L118-R179) [[3]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L158-R200) [[4]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L168-R245) [[5]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L213-R305) [[6]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L237-R338) [[7]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L255-R434) [[8]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L312-R474) [[9]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L338-R494) [[10]](diffhunk://#diff-10d1b9da982f50b7c6bfab68d173ee37f4ff08b981c9b1724b443f6f12557860L357-R511)